### PR TITLE
Set base route

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,5 +1,5 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
+import { themes as prismThemes } from 'prism-react-renderer';
+import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
@@ -11,7 +11,7 @@ const config: Config = {
   url: 'https://apollo.volvox.tech',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/apollo-docs/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Because the nginx config in prod requires a path to be set to serve the docs, the baseUrl needs to be set. However, the existing /docs path seems to collide with something in docusaurus, so the new path /apollo-docs has been chosen.

## Describe your changes
Please describe your changes in detail.

## Issue ticket number and link

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Database
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] CI/CD
